### PR TITLE
fix: name back misrenamed "User" strings

### DIFF
--- a/internal/ingress/controllers/config/config.go
+++ b/internal/ingress/controllers/config/config.go
@@ -336,7 +336,7 @@ type Configuration struct {
 	// Block all requests from given IPs
 	BlockCIDRs []string `json:"block-cidrs"`
 
-	// Block all requests with given UserName-Agent headers
+	// Block all requests with given User-Agent headers
 	BlockUserAgents []string `json:"block-user-agents"`
 
 	// Block all requests with given Referer headers

--- a/pkg/apis/app_process/v1alpha1/register.go
+++ b/pkg/apis/app_process/v1alpha1/register.go
@@ -49,7 +49,7 @@ func AddToContainer(c *restful.Container) error {
 		Doc("List user's apps").
 		Metadata(restfulspec.KeyOpenAPITags, MODULE_TAGS).
 		Param(ws.HeaderParameter(constants.AuthorizationTokenKey, "Auth token").Required(true)).
-		Returns(http.StatusOK, "UserName's app list", response.Response{}))
+		Returns(http.StatusOK, "User's app list", response.Response{}))
 
 	ws.Route(ws.GET("/allapps").
 		To(handler.handleListAllApps).

--- a/pkg/apis/backend/v1/register.go
+++ b/pkg/apis/backend/v1/register.go
@@ -33,7 +33,7 @@ func AddContainer(c *restful.Container) error {
 
 	ws.Route(ws.GET("/user-info").
 		To(handler.handleUserInfo).
-		Doc("UserName information.").
+		Doc("User information.").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(http.StatusOK, "", response.Response{}))
 

--- a/pkg/apis/iam/v1alpha1/templates/templates.go
+++ b/pkg/apis/iam/v1alpha1/templates/templates.go
@@ -158,7 +158,7 @@ func NewUserspaceRoleBinding(username, userspace, role string) *UserspaceRoleBin
 		Subjects: []rbacv1.Subject{
 			{
 				APIGroup: "rbac.authorization.k8s.io",
-				Kind:     "UserName",
+				Kind:     "User",
 				Name:     username,
 			},
 		},


### PR DESCRIPTION
Some unrelated `"User"` strings have been impacted and incorrectly renamed to `"UserName"` during a GoLand refactor, committed in https://github.com/beclab/bfl/pull/31, this PR changes them back.