### PR TITLE
fix: do not use proxy protocol on http endpoints with frp

### DIFF
--- a/internal/frpc/controllers/controllers.go
+++ b/internal/frpc/controllers/controllers.go
@@ -63,7 +63,6 @@ type = "http"
 localPort = 80
 localIp = "{{ .L4ProxyIP }}"
 customDomains = ["{{ .UserZone }}"]
-transport.proxyProtocolVersion = "v1"
 
 [[proxies]]
 name = "web_wildcard"
@@ -71,7 +70,6 @@ type = "http"
 localPort = 80
 localIp = "{{ .L4ProxyIP }}"
 customDomains = ["*.{{ .UserZone }}"]
-transport.proxyProtocolVersion = "v1"
 
 [[proxies]]
 name = "web_ssl"


### PR DESCRIPTION
the Nginx configuration of the L4 Proxy does not accept `Proxy Protocol` header on port 80, and a `400 Bad Request` is returned upon receiving one.

since a `302` redirection to the https endpoints is always returned in normal cases, and all the https endpoints will pass on `Proxy Protocol` infos upstream, we can just simply remove the `Proxy Protocol` directives of http endpoints in FRPc config.