### PR TITLE
feat: use domestic terminus cert&dns service if set

### DIFF
--- a/cmd/apiserver/app/watch_entrance_ip.go
+++ b/cmd/apiserver/app/watch_entrance_ip.go
@@ -177,7 +177,7 @@ func reconcile(ctx context.Context, terminusName constants.TerminusName, zone st
 				}).
 				SetBody(req).
 				SetResult(&v1alpha1.TunnelResponse{}).
-				Post("https://terminus-dnsop.snowinning.com/tunnel")
+				Post(constants.APIDNSSetCloudFlareTunnel)
 
 			if err != nil {
 				log.Error("request cloudflare tunnel api error, ", err)

--- a/pkg/apis/settings/v1alpha1/handler.go
+++ b/pkg/apis/settings/v1alpha1/handler.go
@@ -284,7 +284,7 @@ func (h *Handler) handleEnableHTTPs(req *restful.Request, resp *restful.Response
 
 	o := settingsTask.EnableHTTPSTaskOption{
 		Name:                                terminusName,
-		GenerateURL:                         fmt.Sprintf(constants.NameBindAPICertGenerateFormat, terminusName),
+		GenerateURL:                         fmt.Sprintf(constants.APIFormatCertGenerateRequest, terminusName),
 		AccessToken:                         req.HeaderParameter(constants.AuthorizationTokenKey),
 		ReverseProxyAgentDeploymentName:     ReverseProxyAgentDeploymentName,
 		ReverseProxyAgentDeploymentReplicas: ReverseProxyAgentDeploymentReplicas,

--- a/pkg/apis/settings/v1alpha1/reverseproxyconf.go
+++ b/pkg/apis/settings/v1alpha1/reverseproxyconf.go
@@ -224,7 +224,7 @@ func (configurator *ReverseProxyConfigurator) Configure(ctx context.Context, con
 			}).
 			SetBody(req).
 			SetResult(&TunnelResponse{}).
-			Post("https://terminus-dnsop.snowinning.com/tunnel")
+			Post(constants.APIDNSSetCloudFlareTunnel)
 		if err != nil {
 			return errors.Wrap(err, "failed to request cloudflare tunnel api")
 		}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,6 +2,7 @@ package constants
 
 import (
 	"fmt"
+	"os"
 	"strings"
 )
 
@@ -76,29 +77,34 @@ var (
 )
 
 var (
-	NameBindAPIHost = "frp.snowinning.com"
+	apiPrefixCertService = "https://terminus-cert.snowinning.com"
 
-	nameBindAPIPrefix = "https://terminus-cert.snowinning.com"
+	apiPrefixDNSService = "https://terminus-dnsop.snowinning.com"
 
-	nameDNSAPIPrefix = "https://terminus-dnsop.snowinning.com"
+	APIFormatCertGenerateRequest string
 
-	NameBindAPICertGenerateFormat = nameBindAPIPrefix + "/generate?" + nameParamters
+	APIFormatCertGenerateStatus string
 
-	NameBandAPICertGenerateStatusFormat = nameBindAPIPrefix + "/status?" + nameParamters
+	APIFormatCertDownload string
 
-	NameBindAPICertDownloadFormat = nameBindAPIPrefix + "/download?" + nameParamters
+	APIDNSAddRecord string
 
-	DNSAPIAddDomainRecord = nameDNSAPIPrefix + "/adddnsrecord"
+	APIFormatDNSDeleteRecord string
 
-	DNSAPIDeleteDomainRecordFormat = nameDNSAPIPrefix + "/deldnsrecord?" + nameParamters
+	APIDNSAddCustomDomain string
 
-	DNSAPIAddCustomDomainOnCloudflare = nameDNSAPIPrefix + "/customhostname"
+	APIDNSCheckCustomDomainCname string
 
-	DNSAPICheckCustomDomainCnameStatus = nameDNSAPIPrefix + "/checkcname"
+	APIDNSSetCloudFlareTunnel string
 
 	NameSSLConfigMapName = "zone-ssl-config"
 
 	nameParamters = "name=%s"
+)
+
+const (
+	envTerminusCertServiceAPI = "TERMINUS_CERT_SERVICE_API"
+	envTerminusDNSServiceAPI  = "TERMINUS_DNS_SERVICE_API"
 )
 
 var (
@@ -281,3 +287,42 @@ const (
 	WaitResetPassword     WizardStatus = "wait_reset_password"
 	Completed             WizardStatus = "completed"
 )
+
+func addHTTPSSchemePrefixIfNecessary(original string) string {
+	if !strings.HasPrefix(original, "https://") {
+		return "https://" + original
+	}
+	return original
+}
+
+func setOverridesFromEnv() {
+	if envVar := os.Getenv(envTerminusCertServiceAPI); envVar != "" {
+		apiPrefixCertService = addHTTPSSchemePrefixIfNecessary(envVar)
+	}
+	if envVar := os.Getenv(envTerminusDNSServiceAPI); envVar != "" {
+		apiPrefixDNSService = addHTTPSSchemePrefixIfNecessary(envVar)
+	}
+}
+
+func initEnvDependantVars() {
+	APIFormatCertGenerateRequest = apiPrefixCertService + "/generate?" + nameParamters
+
+	APIFormatCertGenerateStatus = apiPrefixCertService + "/status?" + nameParamters
+
+	APIFormatCertDownload = apiPrefixCertService + "/download?" + nameParamters
+
+	APIDNSAddRecord = apiPrefixDNSService + "/adddnsrecord"
+
+	APIFormatDNSDeleteRecord = apiPrefixDNSService + "/deldnsrecord?" + nameParamters
+
+	APIDNSAddCustomDomain = apiPrefixDNSService + "/customhostname"
+
+	APIDNSCheckCustomDomainCname = apiPrefixDNSService + "/checkcname"
+
+	APIDNSSetCloudFlareTunnel = apiPrefixDNSService + "/tunnel"
+}
+
+func init() {
+	setOverridesFromEnv()
+	initEnvDependantVars()
+}

--- a/pkg/utils/certmanager/certmanager.go
+++ b/pkg/utils/certmanager/certmanager.go
@@ -68,16 +68,16 @@ func NewCertManager(terminusName constants.TerminusName) Interface {
 	c.waitGenerateTimeout = 5 * time.Minute
 
 	// apis
-	c.apiGenerate = fmt.Sprintf(constants.NameBindAPICertGenerateFormat, terminusName)
-	c.apiGenerateStatus = fmt.Sprintf(constants.NameBandAPICertGenerateStatusFormat, terminusName)
-	c.apiDownloadCert = fmt.Sprintf(constants.NameBindAPICertDownloadFormat, terminusName)
+	c.apiGenerate = fmt.Sprintf(constants.APIFormatCertGenerateRequest, terminusName)
+	c.apiGenerateStatus = fmt.Sprintf(constants.APIFormatCertGenerateStatus, terminusName)
+	c.apiDownloadCert = fmt.Sprintf(constants.APIFormatCertDownload, terminusName)
 
-	c.apiAddDNSRecord = constants.DNSAPIAddDomainRecord
-	c.apiDeleteDNSRecord = fmt.Sprintf(constants.DNSAPIDeleteDomainRecordFormat, terminusName)
+	c.apiAddDNSRecord = constants.APIDNSAddRecord
+	c.apiDeleteDNSRecord = fmt.Sprintf(constants.APIFormatDNSDeleteRecord, terminusName)
 
-	c.apiSetCustomDomainOnCloudflare = constants.DNSAPIAddCustomDomainOnCloudflare
+	c.apiSetCustomDomainOnCloudflare = constants.APIDNSAddCustomDomain
 
-	c.apiCheckCustomDomainStatus = constants.DNSAPICheckCustomDomainCnameStatus
+	c.apiCheckCustomDomainStatus = constants.APIDNSCheckCustomDomainCname
 
 	return c
 }


### PR DESCRIPTION
if the environment variable `TERMINUS_CERT_SERVICE_API` is set, it will be used instead of the default `https://terminus-cert.snowinning.com`

if the environment variable `TERMINUS_DNS_SERVICE_API` is set, it will be used instead of the default `https://terminus-dnsop.snowinning.com`