### PR TITLE
feat: add API to retrieve the default reverse proxy config

### DIFF
--- a/pkg/apis/settings/v1alpha1/handler.go
+++ b/pkg/apis/settings/v1alpha1/handler.go
@@ -376,6 +376,16 @@ func (h *Handler) handleGetReverseProxyConfig(req *restful.Request, resp *restfu
 	response.Success(resp, conf)
 }
 
+func (h *Handler) handleGetDefaultReverseProxyConfig(req *restful.Request, resp *restful.Response) {
+	ctx := req.Request.Context()
+	conf, err := GetDefaultReverseProxyConfig(ctx)
+	if err != nil {
+		response.HandleError(resp, errors.Wrap(err, "failed to get the default reverse proxy config"))
+		return
+	}
+	response.Success(resp, conf)
+}
+
 func (h *Handler) handleGetEnableHTTPSTaskState(req *restful.Request, resp *restful.Response) {
 	name := req.Attribute(constants.UserContextAttribute).(string)
 	t, err := settingsTask.GetEnableHTTPSTaskState(name)

--- a/pkg/apis/settings/v1alpha1/register.go
+++ b/pkg/apis/settings/v1alpha1/register.go
@@ -59,7 +59,7 @@ func AddContainer(c *restful.Container) error {
 
 	ws.Route(ws.POST("/reverse-proxy").
 		To(handler.handleChangeReverseProxyConfig).
-		Doc("Change reverse proxy settings.").
+		Doc("Change the current reverse proxy settings.").
 		Reads(ReverseProxyConfig{}).
 		Param(ws.HeaderParameter(constants.AuthorizationTokenKey, "Auth token").Required(true)).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
@@ -67,7 +67,14 @@ func AddContainer(c *restful.Container) error {
 
 	ws.Route(ws.GET("/reverse-proxy").
 		To(handler.handleGetReverseProxyConfig).
-		Doc("Get reverse proxy settings.").
+		Doc("Get the current reverse proxy settings.").
+		Param(ws.HeaderParameter(constants.AuthorizationTokenKey, "Auth token").Required(true)).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Returns(http.StatusOK, "", response.Response{}))
+
+	ws.Route(ws.GET("/default-reverse-proxy").
+		To(handler.handleGetDefaultReverseProxyConfig).
+		Doc("Get the default reverse proxy config, which will be applied at user activation, if reverse proxy is enabled.").
 		Param(ws.HeaderParameter(constants.AuthorizationTokenKey, "Auth token").Required(true)).
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(http.StatusOK, "", response.Response{}))


### PR DESCRIPTION
adds an API `bfl/settings/v1alpha1/default-reverse-proxy` to get the default reverse proxy config (the one that'll be applied if the user choose to use reverse proxy rather than direct connection when activating)

sample response:
```
{
 "code": 0,
 "message": "success",
 "data": {
  "frp_server": "",
  "frp_port": 0,
  "frp_auth_method": "",
  "frp_auth_token": "",
  "ip": "",
  "enable_cloudflare_tunnel": true,
  "enable_frp": false
 }
```