### PR TITLE
fix: store & check applied dns record of local domain

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -178,6 +178,8 @@ var (
 
 	UserAnnotationNatGatewayIp = fmt.Sprintf("%s/nat-gateway-ip", AnnotationGroup)
 
+	UserAnnotationLocalDomainDNSRecord = fmt.Sprintf("%s/local-domain-dns-record", AnnotationGroup)
+
 	UserAnnotationReverseProxyType = fmt.Sprintf("%s/reverse-proxy-type", AnnotationGroup)
 	ReverseProxyTypeFRP            = "frp"
 	ReverseProxyTypeCloudflare     = "cloudflare"


### PR DESCRIPTION
store applied dns record of local domain in the user object, and only update dns record when the nat ip doesn't match with the stored dns record.