### PR TITLE
feat: add watcher to apply reverse proxy

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -140,6 +140,10 @@ var (
 	ReverseProxyAgentImageVersion    = "v0.1.0"
 	DefaultReverseProxyConfigMapName = "default-reverse-proxy-config"
 	ReverseProxyConfigMapName        = "reverse-proxy-config"
+	ReverseProxyLastAppliedConfigKey = "last-applied-config"
+	ReverseProxyStatusKey            = "status"
+	ReverseProxyStatusApplying       = "applying"
+	ReverseProxyStatusApplied        = "applied"
 
 	ApplyPatchFieldManager = "application/apply-patch"
 

--- a/pkg/watchers/reverse_proxy/reverse_proxy.go
+++ b/pkg/watchers/reverse_proxy/reverse_proxy.go
@@ -1,0 +1,78 @@
+package reverse_proxy
+
+import (
+	"bytetrade.io/web3os/bfl/pkg/apis/settings/v1alpha1"
+	"bytetrade.io/web3os/bfl/pkg/constants"
+	"bytetrade.io/web3os/bfl/pkg/watchers"
+	"context"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+)
+
+var GVR = schema.GroupVersionResource{
+	Group: "", Version: "v1", Resource: "configmaps",
+}
+
+type Subscriber struct {
+	*watchers.Watchers
+	configurator *v1alpha1.ReverseProxyConfigurator
+}
+
+func NewSubscriber(w *watchers.Watchers) (*Subscriber, error) {
+	configurator, err := v1alpha1.NewReverseProxyConfigurator()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize reverse proxy configurator: %w", err)
+	}
+	return &Subscriber{
+		Watchers:     w,
+		configurator: configurator,
+	}, nil
+}
+
+func (s *Subscriber) Handler() cache.ResourceEventHandler {
+	handleFunc := func(obj interface{}) {
+		s.Watchers.Enqueue(
+			watchers.EnqueueObj{
+				Subscribe: s,
+				Obj:       obj,
+			},
+		)
+	}
+	return cache.FilteringResourceEventHandler{
+		FilterFunc: func(obj interface{}) bool {
+			cm, ok := obj.(*corev1.ConfigMap)
+			if !ok {
+				klog.Error("not configmap resource, invalid obj")
+				return false
+			}
+
+			if cm.Namespace != constants.Namespace || cm.Name != constants.ReverseProxyConfigMapName {
+				return false
+			}
+
+			return true
+		},
+
+		Handler: cache.ResourceEventHandlerFuncs{
+			AddFunc: handleFunc,
+			UpdateFunc: func(_, new interface{}) {
+				handleFunc(new)
+			},
+			DeleteFunc: func(_ interface{}) {
+			},
+		},
+	}
+}
+
+func (s *Subscriber) Do(ctx context.Context, _ interface{}, _ watchers.Action) error {
+	klog.Infof("handling reverse proxy config event")
+
+	if err := s.configurator.Configure(ctx); err != nil {
+		return fmt.Errorf("failed to get reverse proxy config configmap: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
add a watcher for reverse proxy ConfigMap events, which is responsible for watching the `reverse-proxy-config` ConfigMap and applying the config if necessary.

the reverse proxy operations in the current APIs `/bfl/settings/v1alpha1/reverse-proxy` and `/bfl/settings/v1alpha1/ssl/enable` are moved into the watcher, leaving only the logic of writing the expected config to the ConfigMap. The api scheme is not changed though, so the frontend does not need to be changed accordingly.