### PR TITLE
fix: fetch current user object before every configure operation

### DIFF
--- a/pkg/apis/settings/v1alpha1/reverseproxyconf.go
+++ b/pkg/apis/settings/v1alpha1/reverseproxyconf.go
@@ -232,6 +232,10 @@ func (configurator *ReverseProxyConfigurator) markApplied(ctx context.Context, c
 }
 
 func (configurator *ReverseProxyConfigurator) Configure(ctx context.Context) (err error) {
+	configurator.user, err = configurator.userOp.GetUser("")
+	if err != nil {
+		return errors.Wrap(err, "failed to get user")
+	}
 	cm, err := configurator.kubeClient.CoreV1().ConfigMaps(constants.Namespace).Get(ctx, constants.ReverseProxyConfigMapName, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {


### PR DESCRIPTION
fetch the latest user object because the one we're holding is likely outdated.