### PR TITLE
feat: add error log to frpc

### DIFF
--- a/Dockerfile.frpc
+++ b/Dockerfile.frpc
@@ -24,7 +24,7 @@ COPY . bytetrade.io/web3os/bfl-frpc/
 RUN cd bytetrade.io/web3os/bfl-frpc/ && \
   CGO_ENABLED=0 go build -ldflags="-s -w" -a -o frpc-agent cmd/frpc/main.go
 
-FROM beclab/frpc-base:v0.56.1
+FROM beclab/frpc-base:v0.56.2
 WORKDIR /
 COPY --from=builder /workspace/bytetrade.io/web3os/bfl-frpc/frpc-agent .
 RUN ln -s /usr/bin/frpc


### PR DESCRIPTION
update base image of frpc to `v0.56.2` which adds necessary logs into the frpc agent.