### PR TITLE
feat: support configuring custom domain in FRP mode

### DIFF
--- a/cmd/frpc/main.go
+++ b/cmd/frpc/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytetrade.io/web3os/bfl/pkg/constants"
 	"flag"
 	"fmt"
 	"net/url"
@@ -63,6 +64,7 @@ func flags() error {
 	if username == "" {
 		return errors.New("missing flag 'username'")
 	}
+	constants.Username = username
 
 	if authMethod == v1alpha2.FRPAuthMethodToken && authToken == "" {
 		return errors.New("auth method is selected as token but no token is provided")

--- a/internal/ingress/api/app.bytetrade.io/v1alpha1/application_types.go
+++ b/internal/ingress/api/app.bytetrade.io/v1alpha1/application_types.go
@@ -1,6 +1,7 @@
 package v1alpha1
 
 import (
+	"fmt"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -114,6 +115,14 @@ type ApplicationList struct {
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []Application `json:"items"`
 }
+
+var (
+	AppEntranceCertConfigMapLabel   = fmt.Sprintf("%s/%s", GroupVersion.Group, "custom-domain-cert")
+	AppEntranceCertConfigMapNameTpl = "%s-ssl-config"
+	AppEntranceCertConfigMapCertKey = "cert"
+	AppEntranceCertConfigMapKeyKey  = "key"
+	AppEntranceCertConfigMapZoneKey = "zone"
+)
 
 func init() {
 	SchemeBuilder.Register(&Application{}, &ApplicationList{})

--- a/internal/ingress/controllers/controllers.go
+++ b/internal/ingress/controllers/controllers.go
@@ -71,6 +71,13 @@ type NginxController struct {
 
 	// user's applications
 	apps []v1alpha1App.Application
+
+	customDomainsWithCert map[string]customDomainCertPath
+}
+
+type customDomainCertPath struct {
+	certPath string
+	keyPath  string
 }
 
 func (r *NginxController) RunNginx() error {
@@ -177,6 +184,21 @@ func (r *NginxController) generateCustomDomainNginxServers() ([]config.CustomSer
 	servers := make([]config.CustomServer, 0)
 	alias := []string{}
 
+	userop, err := operator.NewUserOperator()
+	if err != nil {
+		return nil, fmt.Errorf("create user operator err: %v", err)
+	}
+	reverseProxyType, err := userop.GetReverseProxyType()
+	if err != nil {
+		return nil, fmt.Errorf("get reverse proxy type err: %v", err)
+	}
+
+	if reverseProxyType == constants.ReverseProxyTypeFRP {
+		if err := r.writeCustomDomainCertificates(); err != nil {
+			return nil, fmt.Errorf("failed to write custom domain certificates: %v", err)
+		}
+	}
+
 	for _, app := range r.apps {
 		if app.Spec.Entrances == nil || len(app.Spec.Entrances) == 0 {
 			klog.Warningf("invalid app %q custom domain, ignore it. app=%s", app.Spec.Name, utils.PrettyJSON(app.Spec))
@@ -209,7 +231,26 @@ func (r *NginxController) generateCustomDomainNginxServers() ([]config.CustomSer
 				continue
 			}
 
-			if r.sslConfigData != nil {
+			if certPath, certExists := r.customDomainsWithCert[customDomainName]; certExists && reverseProxyType == constants.ReverseProxyTypeFRP {
+				s := config.CustomServer{
+					Server: config.Server{
+						Hostname:   customDomainName,
+						Aliases:    alias,
+						EnableSSL:  true,
+						EnableAuth: true,
+						Locations: []config.Location{
+							{
+								Prefix:    "/",
+								ProxyPass: fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", entranceServiceAddr.Host, app.Spec.Namespace, entranceServiceAddr.Port),
+							},
+						},
+						EnableAnalytics: false,
+					},
+					SslCertPath: certPath.certPath,
+					SslKeyPath:  certPath.keyPath,
+				}
+				servers = append(servers, s)
+			} else if r.sslConfigData != nil {
 				zone := r.sslConfigData["zone"]
 				certName, keyName := fmt.Sprintf("x.%s.crt", zone), fmt.Sprintf("x.%s.key", zone)
 
@@ -457,6 +498,40 @@ func (r *NginxController) writeCertificates(certData, keyData string) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func (r *NginxController) writeCustomDomainCertificates() error {
+	customDomainsWithCert := make(map[string]customDomainCertPath)
+	cmList := corev1.ConfigMapList{}
+	err := r.List(context.Background(), &cmList, client.MatchingLabels{v1alpha1App.AppEntranceCertConfigMapLabel: "true"})
+	if err != nil {
+		return fmt.Errorf("list custom domain cert configmaps err: %v", err)
+	}
+	for _, cm := range cmList.Items {
+		zone := cm.Data[v1alpha1App.AppEntranceCertConfigMapZoneKey]
+		certData := cm.Data[v1alpha1App.AppEntranceCertConfigMapCertKey]
+		keyData := cm.Data[v1alpha1App.AppEntranceCertConfigMapKeyKey]
+		if zone == "" || certData == "" || keyData == "" {
+			klog.Warningf("invalid custom domain config map %s, zone: %s, certData: %s, keyData: %s", cm.Name, zone, certData, keyData)
+			continue
+		}
+		certPath := filepath.Join(nginx.DefNgxSSLCertificationPath, fmt.Sprintf("%s.crt", zone))
+		keyPath := filepath.Join(nginx.DefNgxSSLCertificationPath, fmt.Sprintf("%s.key", zone))
+
+		err := file.WriteFile(certPath, certData, false)
+		if err != nil {
+			return err
+		}
+
+		err = file.WriteFile(keyPath, keyData, false)
+		if err != nil {
+			return err
+		}
+
+		customDomainsWithCert[zone] = customDomainCertPath{certPath: certPath, keyPath: keyPath}
+	}
+	r.customDomainsWithCert = customDomainsWithCert
 	return nil
 }
 

--- a/pkg/apis/iam/v1alpha1/operator/user_operator.go
+++ b/pkg/apis/iam/v1alpha1/operator/user_operator.go
@@ -105,6 +105,14 @@ func (o *UserOperator) GetTerminusStatus(user *iamV1alpha2.User) string {
 	return o.GetUserAnnotation(user, constants.UserTerminusWizardStatus)
 }
 
+func (o *UserOperator) GetReverseProxyType() (string, error) {
+	user, err := o.GetUser("")
+	if err != nil {
+		return "", err
+	}
+	return o.GetUserAnnotation(user, constants.UserAnnotationReverseProxyType), nil
+}
+
 func (o *UserOperator) GetLoginBackground(user *iamV1alpha2.User) string {
 	b := o.GetUserAnnotation(user, constants.UserLoginBackground)
 	if b == "" {

--- a/pkg/apis/settings/v1alpha1/handler_application.go
+++ b/pkg/apis/settings/v1alpha1/handler_application.go
@@ -1,19 +1,26 @@
 package v1alpha1
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"io"
-
+	appv1 "bytetrade.io/web3os/bfl/internal/ingress/api/app.bytetrade.io/v1alpha1"
 	"bytetrade.io/web3os/bfl/internal/log"
 	"bytetrade.io/web3os/bfl/pkg/api"
 	"bytetrade.io/web3os/bfl/pkg/api/response"
 	"bytetrade.io/web3os/bfl/pkg/apis/iam/v1alpha1/operator"
+	"bytetrade.io/web3os/bfl/pkg/apiserver/runtime"
 	"bytetrade.io/web3os/bfl/pkg/app_service/v1"
 	"bytetrade.io/web3os/bfl/pkg/constants"
 	"bytetrade.io/web3os/bfl/pkg/utils"
 	"bytetrade.io/web3os/bfl/pkg/utils/certmanager"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/emicklei/go-restful/v3"
 	iamV1alpha2 "kubesphere.io/api/iam/v1alpha2"
@@ -77,6 +84,73 @@ func (h *Handler) getAppPolicy(req *restful.Request, resp *restful.Response) {
 	response.Success(resp, policy)
 }
 
+func (h *Handler) handleCertConfig(ctx context.Context, customDomain map[string]interface{}) error {
+	cert, key, thirdPartyDomain := customDomain[appv1.AppEntranceCertConfigMapCertKey], customDomain[appv1.AppEntranceCertConfigMapKeyKey], customDomain[constants.ApplicationThirdPartyDomain]
+	if cert == nil || key == nil || thirdPartyDomain == nil {
+		log.Infof("skip storing empty cert config, cert: %s, key: %s, thirdPartyDomain: %s", cert, key, thirdPartyDomain)
+		return nil
+	}
+	var certData, keyData, zoneData string
+	certData, ok := cert.(string)
+	if !ok {
+		return nil
+	}
+	keyData, ok = key.(string)
+	if !ok {
+		return nil
+	}
+	zoneData, ok = thirdPartyDomain.(string)
+	if !ok {
+		return nil
+	}
+	if len(certData) == 0 || len(keyData) == 0 || len(zoneData) == 0 {
+		log.Infof("skip storing empty cert config, cert: %s, key: %s, thirdPartyDomain: %s", cert, key, thirdPartyDomain)
+		return nil
+	}
+	configMapName := fmt.Sprintf(appv1.AppEntranceCertConfigMapNameTpl, zoneData)
+
+	client, err := runtime.NewKubeClientInCluster()
+	if err != nil {
+		return err
+	}
+	err = client.Kubernetes().CoreV1().ConfigMaps(constants.Namespace).Delete(ctx, configMapName, metav1.DeleteOptions{})
+	if err != nil && !apierrors.IsNotFound(err) {
+		return err
+	}
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      configMapName,
+			Namespace: constants.Namespace,
+			Labels: map[string]string{
+				appv1.AppEntranceCertConfigMapLabel: "true",
+			},
+		},
+		Data: map[string]string{
+			appv1.AppEntranceCertConfigMapKeyKey:  keyData,
+			appv1.AppEntranceCertConfigMapCertKey: certData,
+			appv1.AppEntranceCertConfigMapZoneKey: zoneData,
+		},
+	}
+	_, err = client.Kubernetes().CoreV1().ConfigMaps(constants.Namespace).Create(ctx, configMap, metav1.CreateOptions{})
+	return err
+}
+
+func (h *Handler) checkCertExists(ctx context.Context, domainName string) error {
+	configMapName := fmt.Sprintf(appv1.AppEntranceCertConfigMapNameTpl, domainName)
+	client, err := runtime.NewKubeClientInCluster()
+	if err != nil {
+		return err
+	}
+	_, err = client.Kubernetes().CoreV1().ConfigMaps(constants.Namespace).Get(ctx, configMapName, metav1.GetOptions{})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return errors.New("current reverse proxy mode is FRP, the HTTPS certificate and key for custom domain must be uploaded")
+		}
+		return fmt.Errorf("failed to check existence of HTTPS cert config map: %v", err)
+	}
+	return nil
+}
+
 func (h *Handler) setupAppCustomDomain(req *restful.Request, resp *restful.Response) {
 	appName := req.PathParameter(ParamAppName)
 	entranceName := req.PathParameter(ParamEntranceName)
@@ -117,6 +191,21 @@ func (h *Handler) setupAppCustomDomain(req *restful.Request, resp *restful.Respo
 	}
 
 	var reqCustomDomain = h.getCustomDomainValue(customDomain, constants.ApplicationThirdPartyDomain)
+	if reqCustomDomain != "" {
+		authLevel, err := h.getEntranceAuthLevel(appServiceClient, appName, entranceName, token)
+		if err != nil {
+			response.HandleError(resp, err)
+			return
+		}
+		if authLevel == "private" {
+			response.HandleError(resp, errors.New("custom domain can not be set when auth level is private"))
+			return
+		}
+		if err := h.handleCertConfig(req.Request.Context(), customDomain); err != nil {
+			response.HandleError(resp, err)
+			return
+		}
+	}
 
 	existsAppCustomDomain, err := h.getExistsCustomDomain(appServiceClient, appName, entranceName, token)
 	if err != nil {
@@ -171,6 +260,24 @@ func (h *Handler) setupAppCustomDomain(req *restful.Request, resp *restful.Respo
 	case constants.CustomDomainAdd:
 		formatSettings(customDomain, zone, "", "")
 		if operate == constants.CustomDomainUpdate || operate == constants.CustomDomainAdd {
+			op, err := operator.NewUserOperator()
+			if err != nil {
+				response.HandleError(resp, fmt.Errorf("create user operator failed: %v", err))
+			}
+			reverseProxyType, err := op.GetReverseProxyType()
+			if err != nil {
+				response.HandleError(resp, fmt.Errorf("get reverse proxy type failed: %v", err))
+			}
+			if reverseProxyType == constants.ReverseProxyTypeFRP {
+				err := h.checkCertExists(req.Request.Context(), reqCustomDomain)
+				if err != nil {
+					response.HandleError(resp, err)
+					return
+				}
+			} else {
+				log.Infof("reverse proxy type: %s, skip custom domain cert check", reverseProxyType)
+			}
+			h.setCustomDomainValue(customDomain, constants.ApplicationReverseProxyType, reverseProxyType)
 			h.setCustomDomainValue(customDomain, constants.ApplicationCustomDomainCnameTargetStatus, constants.CustomDomainCnameStatusNotset)
 			h.setCustomDomainValue(customDomain, constants.ApplicationCustomDomainCnameStatus, constants.CustomDomainCnameStatusNotset)
 		}
@@ -187,6 +294,63 @@ func (h *Handler) setupAppCustomDomain(req *restful.Request, resp *restful.Respo
 	}
 
 	response.Success(resp, ret)
+	return
+}
+
+func (h *Handler) listEntrancesWithCustomDomain(req *restful.Request, resp *restful.Response) {
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		response.HandleError(resp, err)
+		return
+	}
+	client, err := ctrlclient.New(config, ctrlclient.Options{})
+	if err != nil {
+		response.HandleError(resp, err)
+		return
+	}
+	err = appv1.AddToScheme(client.Scheme())
+	if err != nil {
+		response.HandleError(resp, err)
+		return
+	}
+	appList := &appv1.ApplicationList{}
+	err = client.List(req.Request.Context(), appList)
+	if err != nil {
+		response.HandleError(resp, err)
+		return
+	}
+	var entrances app_service.EntrancesWithCustomDomain
+	for _, app := range appList.Items {
+		if app.Spec.Owner != constants.Username {
+			continue
+		}
+		customDomainSettingsStr, ok := app.Spec.Settings[constants.ApplicationCustomDomain]
+		if !ok || customDomainSettingsStr == "" {
+			continue
+		}
+		customDomainSettings := make(map[string]map[string]string)
+		err = json.Unmarshal([]byte(customDomainSettingsStr), &customDomainSettings)
+		if err != nil {
+			log.Errorf("failed to unmarshal custom domain settings of app %s: %w", app.Name, err)
+			continue
+		}
+		for _, entrance := range app.Spec.Entrances {
+			entranceSetting := customDomainSettings[entrance.Name]
+			if entranceSetting == nil {
+				continue
+			}
+			thirdPartyDomain, ok := entranceSetting[constants.ApplicationThirdPartyDomain]
+			if !ok || thirdPartyDomain == "" {
+				continue
+			}
+			entrances = append(entrances, app_service.EntranceWithCustomDomain{
+				Entrance:     entrance,
+				AppName:      app.Name,
+				CustomDomain: thirdPartyDomain,
+			})
+		}
+	}
+	response.Success(resp, entrances)
 	return
 }
 
@@ -427,6 +591,22 @@ func (h *Handler) getCustomDomainOperation(_reqCustomDomain, _existsAppCustomDom
 	default:
 		return constants.CustomDomainIgnore
 	}
+}
+
+func (h *Handler) getEntranceAuthLevel(appServiceClient *app_service.Client, appName, entranceName, token string) (string, error) {
+	entrances, err := appServiceClient.GetAppEntrances(appName, token)
+	if err != nil {
+		return "", err
+	}
+	var ret string
+	for _, entrance := range entrances {
+		if name, ok := entrance["name"].(string); ok && name == entranceName {
+			if authLevel, ok := entrance["authLevel"].(string); ok {
+				ret = authLevel
+			}
+		}
+	}
+	return ret, nil
 }
 
 func (h *Handler) getExistsCustomDomain(appServiceClient *app_service.Client, appName, entranceName, token string) (string, error) {

--- a/pkg/apis/settings/v1alpha1/register.go
+++ b/pkg/apis/settings/v1alpha1/register.go
@@ -244,6 +244,13 @@ func AddContainer(c *restful.Container) error {
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(http.StatusOK, "", response.Response{Data: app_service.ApplicationsSettings{}}))
 
+	ws.Route(ws.GET("/applications/entrances/setup/domain").
+		To(handler.listEntrancesWithCustomDomain).
+		Doc("List application entrances with a custom third party domain set").
+		Param(ws.HeaderParameter(constants.AuthorizationTokenKey, "Auth token").Required(true)).
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Returns(http.StatusOK, "", response.Response{Data: app_service.EntrancesWithCustomDomain{}}))
+
 	ws.Route(ws.GET("/applications/{"+ParamAppName+"}/setup/domain").
 		To(handler.getAppCustomDomain).
 		Doc("Get application domain settings").

--- a/pkg/app_service/v1/types.go
+++ b/pkg/app_service/v1/types.go
@@ -1,6 +1,7 @@
 package app_service
 
 import (
+	appv1 "bytetrade.io/web3os/bfl/internal/ingress/api/app.bytetrade.io/v1alpha1"
 	"time"
 
 	k8sv1 "k8s.io/api/apps/v1"
@@ -109,6 +110,14 @@ const (
 	ApplicationSettingsDomainKey     = "customDomain"
 	ApplicationAuthorizationLevelKey = "authorizationLevel"
 )
+
+type EntrancesWithCustomDomain []EntranceWithCustomDomain
+
+type EntranceWithCustomDomain struct {
+	appv1.Entrance
+	AppName      string `json:"app_name"`
+	CustomDomain string `json:"custom_domain"`
+}
 
 type ApplicationsSettings map[string]interface{}
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -205,6 +205,8 @@ var (
 
 	ApplicationThirdPartyDomain = "third_party_domain"
 
+	ApplicationReverseProxyType = "reverse_proxy_type"
+
 	ApplicationThirdPartyDomainCert = "ssl_config"
 
 	ApplicationThirdPartyDomainCertKeySuffix = "-domain-ssl-config"
@@ -233,14 +235,16 @@ const (
 )
 
 const (
-	CustomDomainCnameStatusEmpty   = ""
-	CustomDomainCnameStatusSet     = "set"     //
-	CustomDomainCnameStatusNotset  = "unset"   // notset
-	CustomDomainCnameStatusPending = "pending" // pending
-	CustomDomainCnameStatusActive  = "active"  // active
-	CustomDomainCnameStatusNone    = "none"    // none
-	CustomDomainCnameStatusTimeout = "timeout" // timeout
-	CustomDomainCnameStatusError   = "error"   // error
+	CustomDomainCnameStatusEmpty        = ""
+	CustomDomainCnameStatusSet          = "set"     //
+	CustomDomainCnameStatusNotset       = "unset"   // notset
+	CustomDomainCnameStatusPending      = "pending" // pending
+	CustomDomainCnameStatusCertNotFound = "cert-not-found"
+	CustomDomainCnameStatusCertInvalid  = "cert-invalid"
+	CustomDomainCnameStatusActive       = "active"  // active
+	CustomDomainCnameStatusNone         = "none"    // none
+	CustomDomainCnameStatusTimeout      = "timeout" // timeout
+	CustomDomainCnameStatusError        = "error"   // error
 )
 
 var SystemReservedKeyWords = []string{


### PR DESCRIPTION
The API `/settings/v1alpha1/applications/{ParamAppName}/{ParamEntranceName}/setup/domain`, used to configure the custom domain settings of an entrance of an application, accepts two new fields, when `third_party_domain` is provided:
- `cert`: the certificate data for the third party domain
- `key`: the certificate key data for the third party domain

If `third_party_domain`, `cert`, `key` are all non-empty, the cert & key will be stored in a configmap pointing to the `third_party_domain`.

If `third_party_domain` is non-empty, and the current reverse proxy mode of the user is FRP, the `cert` and `key` must be provided, or a certificate configmap pointing to the `third_party_domain` must already exists, if both are unsatisfied, an error will be returned.

Two new cname status are added:
- `cert-not-found`: indicating the cert for the entrance is not found
- `cert-invalid`: indicating the cert for the entrance is found but is invalid
in both cases, the user should upload a new valid cert for the entrance to be accessible

A new API `/settings/v1alpha1/applications/entrances/setup/domain` is added, to list all entrances of the user that has a third party domain configured, response schema:
```
[
...
    {
        // what app this entrance belongs to
        app_name string
        // what third party custom domain this entrance is configured
        custom_domain string
	name string
	host string
	port int
	icon string
	title string
	authLevel string
	invisible bool
	windowPushState bool
    },
...
]
```