### PR TITLE
fix: don't create new branch when checking out ks code

### DIFF
--- a/Dockerfile.frpc
+++ b/Dockerfile.frpc
@@ -11,7 +11,7 @@ COPY go.sum bytetrade.io/web3os/bfl-frpc/go.sum
 
 RUN git clone https://github.com/beclab/kubesphere-ext.git bytetrade.io/kubesphere-ext && \
   cd bytetrade.io/kubesphere-ext && \
-  git checkout -b $ksVersion
+  git checkout $ksVersion
 
 
 RUN cd bytetrade.io/web3os/bfl-frpc && \


### PR DESCRIPTION
the current `git checkout -b` will only create a new branch rather than tracking the upstream branch.