### PR TITLE
fix: replace api terminus-info with olares-info

### DIFF
--- a/config/ingress/nginx.tmpl
+++ b/config/ingress/nginx.tmpl
@@ -466,7 +466,7 @@ http {
 
         location / {
             default_type text/html;
-            return 200 "<h1><a href='https://www.bytetradelab.io/'>Bytetrade</a></h1>";
+            return 200 "<h1><a href='https://olares.xyz/'>Olares</a></h1>";
         }
 
         location /ping {

--- a/pkg/apis/backend/v1/model.go
+++ b/pkg/apis/backend/v1/model.go
@@ -27,6 +27,7 @@ type IPAddress struct {
 	MasterExternalIP string `json:"masterExternalIP"`
 }
 
+// Depreacted
 type TerminusInfo struct {
 	TerminusName    string                 `json:"terminusName"`
 	WizardStatus    constants.WizardStatus `json:"wizardStatus"`
@@ -39,6 +40,20 @@ type TerminusInfo struct {
 	UserDID         string                 `json:"did"`
 	ReverseProxy    string                 `json:"reverseProxy"`
 	Terminusd       string                 `json:"terminusd"`
+}
+
+type OlaresInfo struct {
+	OlaresName      string                 `json:"olaresName"`
+	WizardStatus    constants.WizardStatus `json:"wizardStatus"`
+	Selfhosted      bool                   `json:"selfhosted"`
+	TailScaleEnable bool                   `json:"tailScaleEnable"`
+	OsVersion       string                 `json:"osVersion"`
+	LoginBackground string                 `json:"loginBackground"`
+	Avatar          string                 `json:"avatar"`
+	OlaresID        string                 `json:"olaresId"`
+	UserDID         string                 `json:"did"`
+	ReverseProxy    string                 `json:"reverseProxy"`
+	Olaresd         string                 `json:"olaresd"`
 }
 
 type MyAppsParam struct {

--- a/pkg/apis/backend/v1/register.go
+++ b/pkg/apis/backend/v1/register.go
@@ -43,6 +43,12 @@ func AddContainer(c *restful.Container) error {
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(http.StatusOK, "", response.Response{}))
 
+	ws.Route(ws.GET("/olares-info").
+		To(handler.handleOlaresInfo).
+		Doc("olares information.").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Returns(http.StatusOK, "", response.Response{}))
+
 	ws.Route(ws.GET("/ip").
 		To(handler.handleGetIPAddress).
 		Doc("IP Address.").
@@ -84,6 +90,12 @@ func AddContainer(c *restful.Container) error {
 	wsWizard.Route(wsWizard.GET("/terminus-info").
 		To(handler.handleTerminusInfo).
 		Doc("terminus information.").
+		Metadata(restfulspec.KeyOpenAPITags, tags).
+		Returns(http.StatusOK, "", response.Response{}))
+
+	wsWizard.Route(wsWizard.GET("/olares-info").
+		To(handler.handleOlaresInfo).
+		Doc("olares information.").
 		Metadata(restfulspec.KeyOpenAPITags, tags).
 		Returns(http.StatusOK, "", response.Response{}))
 


### PR DESCRIPTION
change api terminus-info to olares-info, and the response also be changed.

### before
```
type TerminusInfo struct {
	TerminusName    string                 `json:"terminusName"`
	WizardStatus    constants.WizardStatus `json:"wizardStatus"`
	Selfhosted      bool                   `json:"selfhosted"`
	TailScaleEnable bool                   `json:"tailScaleEnable"`
	OsVersion       string                 `json:"osVersion"`
	LoginBackground string                 `json:"loginBackground"`
	Avatar          string                 `json:"avatar"`
	TerminusID      string                 `json:"terminusId"`
	UserDID         string                 `json:"did"`
	ReverseProxy    string                 `json:"reverseProxy"`
	Terminusd       string                 `json:"terminusd"`
}
```

### after
```
type OlaresInfo struct {
	OlaresName      string                 `json:"olaresName"`
	WizardStatus    constants.WizardStatus `json:"wizardStatus"`
	Selfhosted      bool                   `json:"selfhosted"`
	TailScaleEnable bool                   `json:"tailScaleEnable"`
	OsVersion       string                 `json:"osVersion"`
	LoginBackground string                 `json:"loginBackground"`
	Avatar          string                 `json:"avatar"`
	OlaresID        string                 `json:"olaresId"`
	UserDID         string                 `json:"did"`
	ReverseProxy    string                 `json:"reverseProxy"`
	Olaresd         string                 `json:"olaresd"`
}
```