### PR TITLE
fix: migrate from deprecated form3tech-oss/jwt-go to golang-jwt

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,4 +1,4 @@
-FROM golang:1.22.1-bullseye as builder
+FROM golang:1.23.1-bullseye as builder
 
 WORKDIR /workspace
 

--- a/go.mod
+++ b/go.mod
@@ -10,10 +10,10 @@ require (
 	github.com/emicklei/go-restful-openapi/v2 v2.9.1
 	github.com/emicklei/go-restful/v3 v3.8.0
 	github.com/enobufs/go-nats v0.0.1
-	github.com/form3tech-oss/jwt-go v3.2.5+incompatible
 	github.com/go-logr/logr v1.4.1
 	github.com/go-openapi/spec v0.20.7
 	github.com/go-resty/resty/v2 v2.16.2
+	github.com/golang-jwt/jwt/v5 v5.2.0
 	github.com/json-iterator/go v1.1.12
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,6 @@ github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5Kwzbycv
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
-github.com/form3tech-oss/jwt-go v3.2.5+incompatible h1:/l4kBbb4/vGSsdtB5nUe8L7B9mImVMaBPw9L/0TBHU8=
-github.com/form3tech-oss/jwt-go v3.2.5+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
@@ -198,6 +196,8 @@ github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zV
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang-jwt/jwt/v5 v5.2.0 h1:d/ix8ftRUorsN+5eMIlF4T6J8CAt9rch3My2winC1Jw=
+github.com/golang-jwt/jwt/v5 v5.2.0/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/pkg/apis/iam/v1alpha1/handler.go
+++ b/pkg/apis/iam/v1alpha1/handler.go
@@ -381,7 +381,9 @@ func RequestToken(token string, data map[string]string) (*TokenResponse, int, er
 		if err != nil {
 			return nil, -1, errors.Errorf("parse access token err: %v", err)
 		}
-		t.ExpiresAt = claims.ExpiresAt
+		if claims.ExpiresAt != nil {
+			t.ExpiresAt = claims.ExpiresAt.Unix()
+		}
 		return &t, 200, nil
 	}
 	return nil, -1, err

--- a/pkg/apiserver/runtime/jwt.go
+++ b/pkg/apiserver/runtime/jwt.go
@@ -1,11 +1,11 @@
 package runtime
 
-import "github.com/form3tech-oss/jwt-go"
+import "github.com/golang-jwt/jwt/v5"
 
 type Type string
 
 type Claims struct {
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 	// Private Claim Names
 	// TokenType defined the type of the token
 	TokenType Type `json:"token_type,omitempty"`

--- a/pkg/apiserver/runtime/runtime.go
+++ b/pkg/apiserver/runtime/runtime.go
@@ -7,7 +7,7 @@ import (
 	"bytetrade.io/web3os/bfl/pkg/constants"
 
 	"github.com/emicklei/go-restful/v3"
-	"github.com/form3tech-oss/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -52,18 +52,15 @@ func ParseToken(tokenStr string) (*Claims, error) {
 	}
 
 	token, err := jwt.ParseWithClaims(tokenStr, &Claims{}, func(t *jwt.Token) (interface{}, error) {
-		if _, ok := t.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", t.Header["alg"])
-		}
 		return constants.KubeSphereJwtKey, nil
-	})
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
 
 	if err != nil {
 		return nil, err
 	}
 
 	claims, ok := token.Claims.(*Claims)
-	if ok && token.Valid && claims.Username != "" {
+	if ok && claims.Username != "" {
 		return claims, nil
 	}
 	return nil, fmt.Errorf("invalid token, or claims not match")


### PR DESCRIPTION
As stated in https://github.com/beclab/bfl/security/dependabot/20, the current jwt library we depend on has a high-level vulnerability, and also this project has already been archived 3 years ago, this PR migrates the jwt dependency to the https://github.com/golang-jwt/jwt