### PR TITLE
fix: add hs512 as a valid signing method

### DIFF
--- a/pkg/apiserver/runtime/runtime.go
+++ b/pkg/apiserver/runtime/runtime.go
@@ -53,7 +53,7 @@ func ParseToken(tokenStr string) (*Claims, error) {
 
 	token, err := jwt.ParseWithClaims(tokenStr, &Claims{}, func(t *jwt.Token) (interface{}, error) {
 		return constants.KubeSphereJwtKey, nil
-	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS256.Alg()}))
+	}, jwt.WithValidMethods([]string{jwt.SigningMethodHS512.Alg(), jwt.SigningMethodHS256.Alg()}))
 
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Currently only HS256 is considered a valid signing method when parsing JWT token, HS512 should be added.